### PR TITLE
修复 less-loader 引入该文件报错

### DIFF
--- a/styles/form-design.less
+++ b/styles/form-design.less
@@ -1,6 +1,6 @@
 // 表单设计器样式
-@primary-color: "#13c2c2";
-@layout-color : "#9867f7";
+@primary-color: #13c2c2;
+@layout-color : #9867f7;
 
 @primary-background-color: fade(@primary-color, 6%);
 @primary-hover-bg-color  : fade(@primary-color, 20%);


### PR DESCRIPTION
项目直接引入 css 文件，覆盖了原本项目自定的 antd less 的变量
改为引入 form-design.less 文件即可解决
但出现报错 Error evaluating function `fade`: Argument cannot be evaluated to a color 
去掉 form-design.less 的 @primary-color 和 @layout-color 的引号即可解决